### PR TITLE
Allow Scheduling Publisher to use TempFileSystemDirectoryFactory and updates readme with check for WEBSITE_INSTANCE_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ public class RuntimeValidatorsComposer : IComposer
 {
 	public void Compose(IUmbracoBuilder builder)
 	{
-		builder.RuntimeModeValidators()
-			.AddAzureLoadBalancingValidators();
+		// check running on a Azure Web App
+		if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID")))
+			{
+				builder.RuntimeModeValidators()
+					.AddAzureLoadBalancingValidators();
+			}
 	}
 }
 ```

--- a/Umbraco.Community.RuntimeValidators/RuntimeValidatorBuilderExtensions.cs
+++ b/Umbraco.Community.RuntimeValidators/RuntimeValidatorBuilderExtensions.cs
@@ -7,10 +7,15 @@ namespace Umbraco.Community.RuntimeValidators
 	{
 		public static RuntimeModeValidatorCollectionBuilder AddAzureLoadBalancingValidators(this RuntimeModeValidatorCollectionBuilder builder)
 		{
-			return builder
-				.Add<TempFilesValidator>()
-				.Add<HostSyncValidator>()
-				.Add<ExamineValidator>();
+			if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID")))
+			{
+				return builder
+					.Add<TempFilesValidator>()
+					.Add<HostSyncValidator>()
+					.Add<ExamineValidator>();
+			}
+
+			return builder;
 		}
 	}
 }

--- a/Umbraco.Community.RuntimeValidators/RuntimeValidatorBuilderExtensions.cs
+++ b/Umbraco.Community.RuntimeValidators/RuntimeValidatorBuilderExtensions.cs
@@ -7,10 +7,10 @@ namespace Umbraco.Community.RuntimeValidators
 	{
 		public static RuntimeModeValidatorCollectionBuilder AddAzureLoadBalancingValidators(this RuntimeModeValidatorCollectionBuilder builder)
 		{
-				return builder
-					.Add<TempFilesValidator>()
-					.Add<HostSyncValidator>()
-					.Add<ExamineValidator>();
+			return builder
+				.Add<TempFilesValidator>()
+				.Add<HostSyncValidator>()
+				.Add<ExamineValidator>();
 		}
 	}
 }

--- a/Umbraco.Community.RuntimeValidators/RuntimeValidatorBuilderExtensions.cs
+++ b/Umbraco.Community.RuntimeValidators/RuntimeValidatorBuilderExtensions.cs
@@ -7,15 +7,10 @@ namespace Umbraco.Community.RuntimeValidators
 	{
 		public static RuntimeModeValidatorCollectionBuilder AddAzureLoadBalancingValidators(this RuntimeModeValidatorCollectionBuilder builder)
 		{
-			if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID")))
-			{
 				return builder
 					.Add<TempFilesValidator>()
 					.Add<HostSyncValidator>()
 					.Add<ExamineValidator>();
-			}
-
-			return builder;
 		}
 	}
 }

--- a/Umbraco.Community.RuntimeValidators/Validators/AzureLoadBalancing/ExamineValidator.cs
+++ b/Umbraco.Community.RuntimeValidators/Validators/AzureLoadBalancing/ExamineValidator.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Runtime;
 
@@ -43,9 +42,9 @@ namespace Umbraco.Community.RuntimeValidators.Validators.AzureLoadBalancing
 			// Single CMS/Admin Server
 			else if (currentServerRole == ServerRole.SchedulingPublisher)
 			{
-				if (_indexCreatorSettings.CurrentValue.LuceneDirectoryFactory != LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory)
+				if (_indexCreatorSettings.CurrentValue.LuceneDirectoryFactory != LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory && _indexCreatorSettings.CurrentValue.LuceneDirectoryFactory != LuceneDirectoryFactory.TempFileSystemDirectoryFactory)
 				{
-					validationErrorMessage = "Umbraco:CMS:Examine:LuceneDirectoryFactory needs to be set to 'SyncedTempFileSystemDirectoryFactory' in production mode for SchedulingPublisher (Admin) server.";
+					validationErrorMessage = "Umbraco:CMS:Examine:LuceneDirectoryFactory needs to be set to 'SyncedTempFileSystemDirectoryFactory' or 'TempFileSystemDirectoryFactory' in production mode for SchedulingPublisher (Admin) server.";
 					return false;
 				}
 			}


### PR DESCRIPTION
It's perfectly fine for scheduling publisher to be set to TempFileSystemDirectoryFactory so allowing that
I've also added a check for "WEBSITE_INSTANCE_ID" to ensure it's a Azure Web App, can remove that if you think it should be up to the implementer to check